### PR TITLE
Fix feedback-related generated code

### DIFF
--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -12,7 +12,7 @@ pub mod lexer;
 pub mod state_machine;
 
 #[cfg(feature = "feedback-lexer")]
-pub use state_machine::ParserFeedback;
+pub use state_machine::TokensWithFeedback;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ParseError<L, T, E> {


### PR DESCRIPTION
Rename `ParserFeedback` into `TokensWithFeedback` and make it closer to the `std::iter::Iterator` & `IntoIterator`